### PR TITLE
Fix a issue that android sometimes boot with failure

### DIFF
--- a/host/docker/aic-manager/scripts/image-entry
+++ b/host/docker/aic-manager/scripts/image-entry
@@ -29,7 +29,13 @@ function mount_system_images() {
             # --direct-io is default on, and set it as read only
             # busybox does not support --show option, so setup first then find it
             log "setup loop device for $file"
-            if losetup -f -r $file
+            unused_loop=$(losetup -f)
+            loop_index=$(echo $unused_loop | tr -dc '0-9')
+            if [ ! -b $unused_loop ]; then
+                 mknod -m 660 $unused_loop b 7 $loop_index
+            fi
+
+            if losetup $unused_loop $file
             then
                 loop=$(losetup -a | grep $file | cut -d: -f1 | tail -n1)
                 mkdir -p $dest

--- a/host/docker/scripts/aic
+++ b/host/docker/scripts/aic
@@ -888,6 +888,14 @@ function start {
         sleep 1
     done
 
+    if [ "$LOOP_MOUNT_SYSTEM" = "true" ]; then
+        while [ -z "$(ls $(pwd)/workdir/media/system 2>/dev/null)" ]
+        do
+            echo "[AIC] system image hasn't been mounted yet, wait..."
+            sleep 1
+        done
+    fi
+
     for c in ${CONTAINERS[@]}
     do
         if [[ ! $EXISTED_CONTAINERS =~ (^|[[:space:]])"$c"($|[[:space:]]) ]]; then

--- a/host/docker/scripts/aic-build
+++ b/host/docker/scripts/aic-build
@@ -117,6 +117,10 @@ if [ ! -z "$BUILD_NUMBER" ]; then
     sed -ie "2i IMAGE_TAG=$BUILD_NUMBER-$TARGET_PRODUCT-$TARGET_BUILD_VARIANT" $ANDROID_PRODUCT_OUT/aic
 fi
 
+if [ "$BUILD_VARIANT" = "loop_mount" ]; then
+    sed -ie "2i LOOP_MOUNT_SYSTEM=true" $ANDROID_PRODUCT_OUT/aic
+fi
+
 if [ "$BUILD_ANDROID" = "true" ]; then
     if [ ! -e "$ANDROID_WORKDIR/Dockerfile" ]; then
         echo "[BUILD] no Dockerfile!"


### PR DESCRIPTION
When enable loop mount for system image, android may be
launched before system image is mounted.

Tracked-On: OAM-89780
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>