### PR TITLE
add dm-verity support for cic

### DIFF
--- a/host/docker/Android.mk
+++ b/host/docker/Android.mk
@@ -10,3 +10,14 @@ LOCAL_MODULE_SUFFIX :=
 LOCAL_IS_HOST_MODULE := true
 LOCAL_BUILT_MODULE_STEM := $(notdir $(LOCAL_SRC_FILES))
 include $(BUILD_PREBUILT)
+
+# verity img build script
+include $(CLEAR_VARS)
+LOCAL_MODULE := build_verity_img.py
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := scripts/build_verity_img.py
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_MODULE_SUFFIX :=
+LOCAL_IS_HOST_MODULE := true
+LOCAL_BUILT_MODULE_STEM := $(notdir $(LOCAL_SRC_FILES))
+include $(BUILD_PREBUILT)

--- a/host/docker/aic-manager/Dockerfile
+++ b/host/docker/aic-manager/Dockerfile
@@ -49,7 +49,7 @@ FROM build_normal as build_loop_mount
 
 ONBUILD COPY images /images
 ONBUILD COPY scripts/image-entry /images/entry
-
+RUN apt-get -q -y update && apt-get -q -y install cryptsetup-bin
 
 FROM build_${BUILD_VARIANT}
 ARG BUILD_VARIANT

--- a/host/docker/aic-manager/scripts/image-entry
+++ b/host/docker/aic-manager/scripts/image-entry
@@ -3,6 +3,9 @@
 SYSTEM_IMAGES="system.img vendor.img oem.img product.img"
 SYSTEM_IMAGES_DIR=$(cd $(dirname $0) && pwd -P)
 SYSTEM_IMAGES_MOUNT_DIR=/media
+SYSTEM_VERITY_IMAGE=$SYSTEM_IMAGES_DIR/verity_metadata
+SYSTEM_VERITY_HASHTREE=$SYSTEM_IMAGES_DIR/system_hashtree
+SYSTEM_DM=system-dm
 
 function log() {
     echo "[$0 ($$/$PPID)] $@"
@@ -21,29 +24,79 @@ function mount_system_images() {
 
         name=$(basename $img .img)
         dest=$SYSTEM_IMAGES_MOUNT_DIR/$name
+        mkdir -p $dest
         device=$(mount | grep "on $dest" | cut -d' ' -f1)
         if [[ -n $device ]]
         then
             log "$device has already mounted on $dest, skip"
         else
-            # --direct-io is default on, and set it as read only
-            # busybox does not support --show option, so setup first then find it
-            log "setup loop device for $file"
-            unused_loop=$(losetup -f)
-            loop_index=$(echo $unused_loop | tr -dc '0-9')
-            if [ ! -b $unused_loop ]; then
-                 mknod -m 660 $unused_loop b 7 $loop_index
-            fi
-
-            if losetup $unused_loop $file
+            if [[ $name == "system" && -f "$SYSTEM_VERITY_IMAGE" ]]
             then
-                loop=$(losetup -a | grep $file | cut -d: -f1 | tail -n1)
-                mkdir -p $dest
-                log "mount $loop to $dest"
-                mount -o ro $loop $dest
+                if [[ -n $(ls -l /dev/mapper | grep $SYSTEM_DM) ]]; then
+                    log "the dm device for $SYSTEM_DM has been created, skip"
+                else
+                    log "setup loop device for $file"
+                    file_loop=$(losetup -f)
+                    loop_index=$(echo $file_loop | tr -dc '0-9')
+                    if [ ! -b $file_loop ]; then
+	                    mknod -m 660 $file_loop b 7 $loop_index
+                    fi
+                    losetup $file_loop $file
+                    if [ $? -ne 0 ]; then
+                        log "fail to setup loop device for $file"
+                        exit -1
+                    fi
+
+                    roothash_size=$(od -N4 -An -td $SYSTEM_VERITY_IMAGE |tr -d '  \n' |awk '{print $0}')
+                    roothash=$(od -N$roothash_size -j4 -An -tc $SYSTEM_VERITY_IMAGE |tr -d ' \n' |awk '{print $0}')
+
+                    hash_tree_size=$(od -N4 -j$(($roothash_size+4)) -An -td $SYSTEM_VERITY_IMAGE |tr -d ' \n' |awk '{print $0}')
+                    if [[ ! -f "$SYSTEM_VERITY_HASHTREE" ]]; then
+                        log "not find $SYSTEM_VERITY_HASHTREE, create a one..."
+                        dd if=$SYSTEM_VERITY_IMAGE of=$SYSTEM_VERITY_HASHTREE bs=1 count=$hash_tree_size skip=$(($roothash_size+4+4)) conv=notrunc
+                    fi
+
+                    log "setup loop device for $SYSTEM_VERITY_HASHTREE"
+                    hash_loop=$(losetup -f)
+                    loop_index=$(echo $hash_loop | tr -dc '0-9')
+                    if [ ! -b $hash_loop ]; then
+                        mknod -m 660 $hash_loop b 7 $loop_index
+                    fi
+                    losetup $hash_loop $SYSTEM_VERITY_HASHTREE
+                    if [ $? -ne 0 ]; then
+                        log "failed to create the dm device for $file"
+                        exit -1
+                    fi
+
+                    log "create the dm device: $SYSTEM_DM"
+                    veritysetup create $SYSTEM_DM $file_loop $hash_loop $roothash
+                    if [ $? -ne 0 ]; then
+                        log "failed to create the dm device for $file"
+                        exit -1
+                    fi
+                fi
+                log "mount dm device($SYSTEM_DM) to $dest"
+                mount -o ro /dev/mapper/$SYSTEM_DM $dest
             else
-                log "fail to setup loop device"
-                exit -1
+                # --direct-io is default on, and set it as read only
+                # busybox does not support --show option, so setup first then find it
+                log "setup loop device for $file"
+                unused_loop=$(losetup -f)
+                loop_index=$(echo $unused_loop | tr -dc '0-9')
+                if [ ! -b $unused_loop ]; then
+                    mknod -m 660 $unused_loop b 7 $loop_index
+                fi
+
+                if losetup $unused_loop $file
+                then
+                    loop=$(losetup -a | grep $file | cut -d: -f1 | tail -n1)
+                    mkdir -p $dest
+                    log "mount $loop to $dest"
+                    mount -o ro $loop $dest
+                else
+                    log "fail to setup loop device"
+                    exit -1
+                fi
             fi
         fi
     done
@@ -62,12 +115,21 @@ function umount_system_images() {
             log "umount $dest"
             umount $dest
         fi
-        loop=$(losetup -a | grep $file | cut -d: -f1)
-        for lo in $loop
-        do
-            log "detach $lo"
-            losetup -d $lo
-        done
+        if [[ $name == "system" && -f "$SYSTEM_VERITY_IMAGE" ]]
+        then
+            if [[ -n $(ls -l /dev/mapper | grep $SYSTEM_DM) ]]
+            then
+                log "remvoe the dm device: $SYSTEM_DM"
+                veritysetup remove $SYSTEM_DM
+            fi
+        else
+            loop=$(losetup -a | grep $file | cut -d: -f1)
+            for lo in $loop
+            do
+                log "detach $lo"
+                losetup -d $lo
+            done
+        fi
     done
     log $FUNCNAME done
 }

--- a/host/docker/scripts/aic
+++ b/host/docker/scripts/aic
@@ -600,7 +600,7 @@ function install {
     fi
 
     # create aic-manager container
-    AIC_MANAGER_CONTAINER_OPTION="-v /lib/modules:/lib/modules -v /usr/src:/usr/src -v $WORK_DIR/ipc:/ipc -v $WORK_DIR/media:/media:shared"
+    AIC_MANAGER_CONTAINER_OPTION="-v /lib/modules:/lib/modules -v /dev/mapper:/dev/mapper -v /usr/src:/usr/src -v $WORK_DIR/ipc:/ipc -v $WORK_DIR/media:/media:shared"
     AIC_MANAGER_CONTAINER_CMDS="-n $INSTANCE_NUM"
     if [ "$EMULATED_WIFI" = "true" ]; then
         AIC_MANAGER_CONTAINER_OPTION="$AIC_MANAGER_CONTAINER_OPTION -v /proc:/hostproc -v /var/run/docker.sock:/var/run/docker.sock"

--- a/host/docker/scripts/build_verity_img.py
+++ b/host/docker/scripts/build_verity_img.py
@@ -1,0 +1,78 @@
+import logging
+import os
+import os.path
+import re
+import shutil
+import sys
+import tempfile
+import struct
+import math
+import subprocess
+
+FIXED_SALT = "aee087a5be3b982978c923f566a94613496b417f2af592639bc80d141e34dfe7"
+
+def RunCommand(cmd, verbose=None):
+  """Echo and run the given command.
+
+  Args:
+    cmd: the command represented as a list of strings.
+    verbose: show commands being executed.
+  Returns:
+    A tuple of the output and the exit code.
+  """
+  if verbose:
+    print("Running: " + " ".join(cmd))
+  p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  output, _ = p.communicate()
+
+  if verbose:
+    print(output.rstrip())
+  return (output, p.returncode)
+
+def build_verity_metadata(input_img, verity_metadata):
+  cmd = ["veritysetup", "format", "-s", FIXED_SALT, input_img,
+         verity_metadata]
+  output, exit_code = RunCommand(cmd)
+  if exit_code != 0:
+    print("Could not build verity tree! Error: %s" % output)
+    return False
+  for line in output.split("\n"):
+    if (line.find("Root hash") != -1):
+      root = line.split(":")[-1].strip()
+    if (line.find("Salt") != -1):
+      salt = line.split(":")[-1].strip()
+
+  tree_size = int(os.path.getsize(verity_metadata))
+  #print("tree_size=%d" % tree_size)
+
+  header = struct.pack("I64sI",
+      len(root),
+      root,
+      tree_size)
+  #print(header)
+
+  with open(verity_metadata, "r+") as f:
+    hashtree = f.read()
+    f.seek(0)
+    f.write(header)
+    f.write(hashtree)
+    f.flush()
+
+  return True
+
+def main(argv):
+	if len(argv) != 2:
+		print("Usage: build_verity_img.py system.img verity_metadata")
+		sys.exit(1)
+
+	input_file = argv[0]
+	output_file = argv[1]
+	if os.path.exists(output_file):
+		os.remove(output_file)
+
+	# build the verity metadata
+	if not build_verity_metadata(input_file, output_file):
+		return False
+
+if __name__ == '__main__':
+	main(sys.argv[1:])


### PR DESCRIPTION
currently the dm-verity only for the system.img.

At build stage, will generate the verity_metadata which format
is like this below {roothash_size|roothash|hashtree_size|hashtree}.
At install stage, if w/ "-s" option, it will parse the verity_metadata
to get the hashtree and that will be pushed into aic-manager
together with the metadata image
(do this in install stage because it will cost some times...)
At start stage, if there find the verity_metadta, then try to get the
roothash from the metadata and create the dm device for
system.img

Tracked-On: OAM-89713
Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>