### PR TITLE
docker-aic-manager: update to gcc 8 to fix compile error on 5.4 kernel

### DIFF
--- a/host/docker/aic-manager/Dockerfile
+++ b/host/docker/aic-manager/Dockerfile
@@ -1,7 +1,7 @@
 # for different build variant
 ARG BUILD_VARIANT=normal
 
-FROM ubuntu-bionic-aic:1.1 as build_base
+FROM ubuntu-bionic-aic:1.2 as build_base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/host/docker/aic-manager/Dockerfile.base
+++ b/host/docker/aic-manager/Dockerfile.base
@@ -5,11 +5,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 # install essential modules
 RUN apt-get -q -y update \
         && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" \
-        install build-essential kmod libelf-dev libdrm-dev libegl1-mesa-dev libgles2-mesa \
+        install build-essential gcc-8 kmod libelf-dev libdrm-dev libegl1-mesa-dev libgles2-mesa \
         net-tools rfkill iptables iw iproute2 hostapd dnsmasq\
         software-properties-common curl \
         python python-pip pkg-config libfuse-dev \
         && rm -rf /var/lib/apt/lists/*
+
+# use gcc-8 by default
+RUN rm /usr/bin/gcc && ln -s /usr/bin/gcc-8 /usr/bin/gcc
 
 # install docker-cli
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/host/docker/scripts/aic-build
+++ b/host/docker/scripts/aic-build
@@ -146,8 +146,8 @@ if [ "$BUILD_AIC_MANAGER" = "true" ]; then
     if [ ! -z "$DOCKER_BUILD_HTTP_PROXY" ] || [ ! -z "$DOCKER_BUILD_HTTPS_PROXY" ]; then
         BUILD_ARGS="$BUILD_ARGS --build-arg http_proxy=$DOCKER_BUILD_HTTP_PROXY --build-arg https_proxy=$DOCKER_BUILD_HTTPS_PROXY"
     fi
-    if [ -z "$($DOCKER images ubuntu-bionic-aic:1.1 | grep ubuntu-bionic-aic)" ]; then
-        $DOCKER build -t ubuntu-bionic-aic:1.1 -f $AIC_MANAGER_WORKDIR/Dockerfile.base $BUILD_ARGS $AIC_MANAGER_WORKDIR
+    if [ -z "$($DOCKER images ubuntu-bionic-aic:1.2 | grep ubuntu-bionic-aic)" ]; then
+        $DOCKER build -t ubuntu-bionic-aic:1.2 -f $AIC_MANAGER_WORKDIR/Dockerfile.base $BUILD_ARGS $AIC_MANAGER_WORKDIR
     fi
     $DOCKER build $BUILD_ARGS -t $AIC_MANAGER_IMAGE $AIC_MANAGER_WORKDIR
     echo "[BUILD] save aic-manager docker images..."


### PR DESCRIPTION
Tracked-On: OAM-90916
Signed-off-by: lwan89 <liang.wang@intel.com>