### PR TITLE
Separate audio folder for CIC socket creation

### DIFF
--- a/host/docker/scripts/aic
+++ b/host/docker/scripts/aic
@@ -724,7 +724,7 @@ function install {
             ANDROID_CONTAINER_OPTION="$ANDROID_CONTAINER_OPTION --net android --ip $IP --mac-address $MAC -p $(($ADB_PORT+i)):5555"
         fi
 
-        ANDROID_CONTAINER_OPTION="$ANDROID_CONTAINER_OPTION -v $WORK_DIR/ipc/config/audio:/data/misc/audio"
+        ANDROID_CONTAINER_OPTION="$ANDROID_CONTAINER_OPTION -v $WORK_DIR/audio:/data/misc/audio"
         $DOCKER container create --name android$i --cpuset-cpus=$CPU_SET --cpuset-mems=${MEM_NODES:-0} --privileged=true $ANDROID_CONTAINER_OPTION $ANDROID_IMAGE $ANDROID_CONTAINER_CMDS $i
 
     done


### PR DESCRIPTION
Pulseaudio sockets get created inside the ipc folder currently.
The workdir/ipc directory gets mapped to /ipc inside android.
The audio folder, which is inside ipc, is mapped separately as:
workdir/ipc/config/audio:/data/misc/audio
The above 2 mappings are causing issues for sepolicy contexts.
Hence, moving audio folder outside ipc to remove ambiguity.

Tracked-On: OAM-91252
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>