### PR TITLE
Install the required tools for FBE in aic

### DIFF
--- a/host/docker/scripts/aic
+++ b/host/docker/scripts/aic
@@ -14,6 +14,19 @@ function check_num {
     esac
 }
 
+function check_required_tools_for_fbe {
+    if [ ! -x "$(command -v pvcreate)" ]; then
+        echo "[AIC] The lvm2 tool seems not installed, will install for you..."
+        sudo apt --assume-yes install lvm2
+    fi
+
+
+    if [ ! -x "$(command -v thin_check)" ]; then
+        echo "[AIC] The thin-provisioning-tools seems not installed, will install for you..."
+        sudo apt --assume-yes install thin-provisioning-tools
+    fi
+}
+
 function check_docker {
     if [ ! -x "$(command -v docker)" ]; then
         echo "[AIC] docker not installed, please install it first!"
@@ -505,6 +518,11 @@ function install {
                 ;;
         esac
     done
+
+    if [ "$ENABLE_FBE" = "true" ]; then
+        check_required_tools_for_fbe
+    fi
+
     check_docker
     check_kernel_header
 


### PR DESCRIPTION
lvm2 and thin-provisioning-tools are needed for FBE. Without
these two tools, CIC with FBE enabled cannot boot up. But cic
users may not know about this, we'd better install these tools
in aic ourselves.

Tracked-On: OAM-91474
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>