### PR TITLE
FBE: Expand data partition size to 8G

### DIFF
--- a/host/docker/scripts/aic
+++ b/host/docker/scripts/aic
@@ -49,7 +49,7 @@ function check_data_img {
         echo "Detect previous data img..."
     else
         echo "Create data image..."
-        dd if=/dev/zero of=$AIC_DATA_IMG bs=2M count=2048
+        dd if=/dev/zero of=$AIC_DATA_IMG bs=2M count=5120
     fi
 }
 
@@ -73,7 +73,7 @@ function prepare_data_partition {
     fi
     # Check lv
     if [ -z "$(sudo lvs | grep $data_name)" ]; then
-        sudo lvcreate -L 2G -T $AIC_VG_NAME/$data_name
+        sudo lvcreate -L 8G -T $AIC_VG_NAME/$data_name
     fi
     # make lvm node under dev
     sudo vgscan --mknodes -v


### PR DESCRIPTION
We set data partition size to 2G previously, it's not
enough. When we install too many APKs, Graphics GFXBench
cannot be launched because of low memory. CTS execution is
blocked as the media content cannot be pushed. Domain
validation of audio/video is also blocked.

Tracked-On: OAM-91549
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>